### PR TITLE
Fixed .net version in workflows

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   release:
 
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
 


### PR DESCRIPTION
The test project had been upgraded to .NET 8 so adjustments had to be done in the workflow files.